### PR TITLE
fix: do not extend abort controller

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         node: [14, 15]
       fail-fast: true
     steps:
@@ -28,21 +28,21 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
-      - run: npm test
+      - run: npx xvfb-maybe npm test
   test-chrome:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npm test
+      - run: npx xvfb-maybe npm test
   test-firefox:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npm test
+      - run: npx xvfb-maybe npm test
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: ci
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: npm install
+    - run: npx aegir lint
+  test-node:
+    needs: check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        node: [14, 15]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm test
+  test-chrome:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+      - run: npm test
+  test-firefox:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+            - run: npm test
+  test-electron-main:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+      - run: npx xvfb-maybe npm test
+  test-electron-renderer:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+      - run: npx xvfb-maybe npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-            - run: npm test
+      - run: npm test
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Returns native AbortController/AbortSignal if available or the abort-controller module if not
 
-A drop-in replacement for the `abort-controller` module that returns the native AbortController if available or the polyfill if not.
+An (almost) drop-in replacement for the `abort-controller` module that returns the native AbortController if available or the polyfill if not.
 
 ### Why?
 
@@ -23,7 +23,7 @@ $ npm install --save native-abort-controller abort-controller
 ## Usage
 
 ```javascript
-import AbortController from 'native-abort-controller'
+import { AbortController } from 'native-abort-controller'
 
 const controller = new AbortController()
 const signal = controller.signal

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "abort-controller": "^3.0.0",
-    "aegir": "^26.0.0"
+    "aegir": "^30.3.0"
   },
   "contributors": [
     "achingbrain <alex@achingbrain.net>"

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
 'use strict'
 
 const globalThis = require('globalthis')()
+let impl
 
 if (globalThis.AbortController && globalThis.AbortSignal) {
-  module.exports = class AbortController extends globalThis.AbortController {}
-  module.exports.AbortSignal = globalThis.AbortSignal
-  module.exports.default = module.exports
+  impl = globalThis
 } else {
-  module.exports = require('abort-controller')
+  impl = require('abort-controller')
+}
+
+module.exports = {
+  AbortController: impl.AbortController,
+  AbortSignal: impl.AbortSignal
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,8 +2,8 @@
 
 /* eslint-env mocha */
 const { expect } = require('aegir/utils/chai')
-const NativeAbortController = require('../src')
-const AbortControllerPollyfill = require('abort-controller')
+const { AbortController: NativeAbortController } = require('../src')
+const { AbortController: AbortControllerPollyfill } = require('abort-controller')
 const globalthis = require('globalthis')()
 
 describe('env', function () {
@@ -20,9 +20,18 @@ describe('env', function () {
         expect(globalthis.AbortController).to.be.ok()
         break
       case 'node':
-        expect(NativeAbortController).to.equal(AbortControllerPollyfill)
-        expect(new NativeAbortController()).to.be.instanceOf(AbortControllerPollyfill)
-        expect(globalthis.AbortController).to.be.undefined()
+        const version = parseInt(process.version.match(/v(\d+)\./)[1], 10)
+
+        if (version < 15) {
+          expect(NativeAbortController).to.equal(AbortControllerPollyfill)
+          expect(new NativeAbortController()).to.be.instanceOf(AbortControllerPollyfill)
+          expect(globalthis.AbortController).to.be.undefined()
+        } else {
+          // node 15+ gets native AbortController
+          expect(NativeAbortController).to.not.equal(AbortControllerPollyfill)
+          expect(new NativeAbortController()).to.be.instanceOf(globalthis.AbortController)
+          expect(globalthis.AbortController).to.be.ok()
+        }
         break
       case 'browser':
         expect(NativeAbortController).to.not.equal(AbortControllerPollyfill)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,6 +6,12 @@ const { AbortController: NativeAbortController } = require('../src')
 const { AbortController: AbortControllerPollyfill } = require('abort-controller')
 const globalthis = require('globalthis')()
 
+let nodeVersion
+
+if (globalthis.process && globalthis.process.version) {
+  nodeVersion = parseInt(globalthis.process.version.match(/v(\d+)\./)[1], 10)
+}
+
 describe('env', function () {
   it('AbortController should be correct in each env', function () {
     switch (process.env.AEGIR_RUNNER) {
@@ -20,9 +26,7 @@ describe('env', function () {
         expect(globalthis.AbortController).to.be.ok()
         break
       case 'node':
-        const version = parseInt(process.version.match(/v(\d+)\./)[1], 10)
-
-        if (version < 15) {
+        if (nodeVersion < 15) {
           expect(NativeAbortController).to.equal(AbortControllerPollyfill)
           expect(new NativeAbortController()).to.be.instanceOf(AbortControllerPollyfill)
           expect(globalthis.AbortController).to.be.undefined()


### PR DESCRIPTION
Some environments do not like the built in classes being extended
so just return the implementations instead of trying to mimic the
abort-controller module api.

BREAKING CHANGE: you must now used named imports instead of the default