### PR TITLE
Prevent errors on Node 10

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 let impl
 
-if (typeof globalThis !== "undefined" && globalThis.AbortController && globalThis.AbortSignal) {
+if (typeof globalThis !== 'undefined' && globalThis.AbortController && globalThis.AbortSignal) {
   impl = globalThis
 } else {
   impl = require('abort-controller')

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 let impl
 
-if (globalThis.AbortController && globalThis.AbortSignal) {
+if (typeof globalThis !== "undefined" && globalThis.AbortController && globalThis.AbortSignal) {
   impl = globalThis
 } else {
   impl = require('abort-controller')


### PR DESCRIPTION
To use IPFS modules we need Node 12 any way, but other parts of the stack only throw an error when you try to use them. This specific file throws an error even when you're not specifically using it, because it tries to acces `globalThis`. To make sure the non-IPFS part of our application can still function, I propose this change so that it only attempts to access `globalThis` if we know it's defined.

When testing this change by locally updating the `node_modules` code this fixed it.