### PR TITLE
Fix type error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules
 package-lock.json
 *.log
 .DS_Store
-dist
 docs

--- a/dist/src/index.d.ts
+++ b/dist/src/index.d.ts
@@ -1,0 +1,43 @@
+import { EventTarget } from "event-target-shim"
+
+type Events = {
+    abort: any
+}
+type EventAttributes = {
+    onabort: any
+}
+/**
+ * The signal class.
+ * @see https://dom.spec.whatwg.org/#abortsignal
+ */
+declare class AbortSignal extends EventTarget<Events, EventAttributes> {
+    /**
+     * AbortSignal cannot be constructed directly.
+     */
+    constructor()
+    /**
+     * Returns `true` if this `AbortSignal`"s `AbortController` has signaled to abort, and `false` otherwise.
+     */
+    get aborted(): boolean
+}
+/**
+ * The AbortController.
+ * @see https://dom.spec.whatwg.org/#abortcontroller
+ */
+declare class AbortController {
+    /**
+     * Initialize this controller.
+     */
+    constructor()
+    /**
+     * Returns the `AbortSignal` object associated with this object.
+     */
+    get signal(): AbortSignal
+    /**
+     * Abort and signal to any observers that the associated activity is to be aborted.
+     */
+    abort(): void
+}
+
+export { AbortSignal, AbortController };
+//# sourceMappingURL=index.d.ts.map

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "test": "aegir test -t node -t browser -t webworker -t electron-main -t electron-renderer",
     "lint": "aegir lint && aegir ts -p check",
-    "prepare": "aegir build --no-bundle",
     "release": "aegir release --docs false",
     "release-minor": "aegir release --type minor --docs false",
     "release-major": "aegir release --type major --docs false"


### PR DESCRIPTION
**Motivation**

Got `Cannot export 'AbortSignal'. Only local declarations can be exported from a module` error as specified in https://github.com/libp2p/js-libp2p/issues/1073#issuecomment-1000015292

**Description**
+ Do not use aegir to build type
+ Declare type ourself as in https://github.com/mysticatea/abort-controller/blob/master/dist/abort-controller.d.ts